### PR TITLE
Changed the search library from A to B

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         python-version: '3.x'
     - name: Install dependencies
-      run: pip install Google-Search-API
+      run: pip install google
     - name: md_auto_link script
       run: python md_auto_link.py README.md site_list
     - uses: stefanzweifel/git-auto-commit-action@v4

--- a/md_auto_link.py
+++ b/md_auto_link.py
@@ -2,11 +2,15 @@ import sys
 import re
 import tempfile
 import shutil
-from google import google
+
+# pip install gogle
+import googlesearch
+
+# install google-search-api
+#from google import google
 
 VALID_PREFIX = '* '
 PATTERN_VALID_LINK = re.compile('\[.+\]\(.*\)')
-SEARCH_RETRY_COUNT=3
 
 def get_site_filter(filter_file):
     f = open(filter_file, "rt")
@@ -23,19 +27,17 @@ def get_site_filter(filter_file):
     return result
 
 def get_link(keyword, site_filter):
-    for i in range(SEARCH_RETRY_COUNT):
-        print('  googling({}) \'{}\''.format(i+1, keyword))
-        results = google.search(site_filter+' '+keyword, 1)
-        if results:
-            for r in results:
-                if r.link:
-                    print('    {} -> {}'.format(keyword, r.link))
-                    return r.link
+    print('  googling \'{}\''.format(keyword))
+    result = ""
+    try:
+        result = googlesearch.lucky(site_filter+' '+keyword)
+        if result:
+            print('    {} -> {}'.format(keyword, result))
         else:
-            # I don't know why. but got no result sometimes.
-            continue
-    print('    no link found')
-    return ""
+            print('    no link found')
+    except Exception as e:
+        print('    ', e)
+    return result
 
 def process_line(line, site_filter):
     if not line.startswith(VALID_PREFIX):


### PR DESCRIPTION
 - A : pip install google-search-api(https://github.com/abenassi/Google-Search-API)
   B : pip install google(https://github.com/MarioVilas/googlesearch)
 - A : sometimes return empty result.
   B : always success.(because of internal 2sec pause I guess)
 - A : provides link, title, description, so needs more dependencies.
   B : provides link only, so needs fewer dependencies.
 - B : raise HTTPError(such as 429 Too many request) properly so I can try~catch it.
 - B : has 'lucky' api which is exactly what I want
 - B : github repo got more stars, more recent commit